### PR TITLE
added Ruby syntax highlighting to .podspec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Extension adds Ruby syntax highlighting for:
 
-* [CocoaPods's](https://cocoapods.org) Podfile
+* [CocoaPods's](https://cocoapods.org) Podfile and *.podspec files
 * [fastlane's](https://fastlane.tools) Fastfile, and a few others.
 
 ![https://github.com/orta/vscode-ios-common-files/raw/master/preview.png](https://github.com/orta/vscode-ios-common-files/raw/master/preview.png)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     ],
     "activationEvents": [
         "workspaceContains:Podfile",
+        "workspaceContains:*.podspec",
         "workspaceContains:Fastfile",
         "workspaceContains:fastlane/Fastfile"
     ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
                 "Fastfile",
                 "Appfile",
                 "Snapfile",
-                "Deliverfile"
+                "Deliverfile",
+                "*.podspec"
             ]
         }]
     },


### PR DESCRIPTION
Hi,

As the PR title said, I added Ruby syntax highlighting to .podspec files.

It looked like the only change to do was to add the file extension in `package.json`. Let me know if it needs to be changed anywhere else :-).

disclaimer : I have not tested my changes as I don't know how to build vscode extensions and don't really have time to learn how to. The change seemed simple enough to make.

Let me know if you have any questions.